### PR TITLE
GCP-409 GCP-400 Fix query timeout, add retry for invalid JWT token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ ENV LC_ALL=en_US.UTF-8
 ## Composer - deps always cached unless changed
 # First copy only composer files
 COPY composer.* /code/
+COPY patches /code/patches
 
 # Download dependencies, but don't run scripts or init autoloaders as the app is missing
 RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,13 @@
     "require": {
         "php": "^8.2",
         "ext-odbc": "*",
+        "cweagans/composer-patches": "^1.7",
         "google/cloud-bigquery": "^1.23",
         "jdorn/sql-formatter": "^1.2",
         "keboola/php-component": "^9.0",
         "keboola/table-backend-utils": "^2.0"
     },
     "require-dev": {
-        "cweagans/composer-patches": "^1.7",
         "keboola/coding-standard": ">=7.0.2",
         "keboola/datadir-tests": "^5.3",
         "keboola/php-temp": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Transformation component for Google BigQuery",
     "license": "MIT",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-odbc": "*",
         "google/cloud-bigquery": "^1.23",
         "jdorn/sql-formatter": "^1.2",
@@ -11,10 +11,11 @@
         "keboola/table-backend-utils": "^2.0"
     },
     "require-dev": {
-        "php-parallel-lint/php-parallel-lint": "^1.3",
+        "cweagans/composer-patches": "^1.7",
         "keboola/coding-standard": ">=7.0.2",
         "keboola/datadir-tests": "^5.3",
         "keboola/php-temp": "^2.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.5",
         "symfony/process": "^5.0"
@@ -38,7 +39,6 @@
             "@tests-phpunit",
             "@tests-datadir"
         ],
-
         "phpstan": "phpstan analyse ./src ./tests --level=max --no-progress -c phpstan.neon",
         "phpcs": "phpcs -n --ignore=vendor --extensions=php .",
         "phpcbf": "phpcbf -n --ignore=vendor --extensions=php .",
@@ -58,7 +58,16 @@
         "sort-packages": true,
         "optimize-autoloader": true,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "cweagans/composer-patches": true
+        }
+    },
+    "extra": {
+        "composer-exit-on-patch-failure": true,
+        "patches": {
+            "google/cloud-bigquery": [
+                "patches/google-cloud-bigquery-JobWaitTrait.php.patch"
+            ]
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
         }
     },
     "scripts": {
-        "tests-phpunit": "phpunit",
-        "tests-datadir": "phpunit tests/functional",
+        "tests-phpunit": "phpunit --debug --verbose",
+        "tests-datadir": "phpunit tests/functional  --debug --verbose",
         "tests": [
             "@tests-phpunit",
             "@tests-datadir"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0620c6f763ee5ad46dd963af1b1d402a",
+    "content-hash": "cb50b96993258dc9a2f8e5b53aaafcd6",
     "packages": [
         {
             "name": "brick/math",
@@ -61,6 +61,54 @@
                 }
             ],
             "time": "2022-08-10T22:54:19+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+            },
+            "time": "2022-12-20T22:53:13+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -2720,54 +2768,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "cweagans/composer-patches",
-            "version": "1.7.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cweagans/composer-patches.git",
-                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
-                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "composer/composer": "~1.0 || ~2.0",
-                "phpunit/phpunit": "~4.6"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "cweagans\\Composer\\Patches"
-            },
-            "autoload": {
-                "psr-4": {
-                    "cweagans\\Composer\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Cameron Eagans",
-                    "email": "me@cweagans.net"
-                }
-            ],
-            "description": "Provides a way to patch Composer packages.",
-            "support": {
-                "issues": "https://github.com/cweagans/composer-patches/issues",
-                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
-            },
-            "time": "2022-12-20T22:53:13+00:00"
-        },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a84eb1ef34b7af61aa15da8f2e994bcd",
+    "content-hash": "0620c6f763ee5ad46dd963af1b1d402a",
     "packages": [
         {
             "name": "brick/math",
@@ -1022,7 +1022,7 @@
             ],
             "support": {
                 "issues": "https://github.com/jdorn/sql-formatter/issues",
-                "source": "https://github.com/jdorn/sql-formatter/tree/master"
+                "source": "https://github.com/jdorn/sql-formatter/tree/v1.2.17"
             },
             "time": "2014-01-12T16:20:24+00:00"
         },
@@ -2720,6 +2720,54 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+            },
+            "time": "2022-12-20T22:53:13+00:00"
+        },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.2",
@@ -5086,7 +5134,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-odbc": "*"
     },
     "platform-dev": [],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: '3'
 services:
-  dev:
-    build: .
+  production: &prod
+    build:
+      context: .
     environment:
       - BQ_DATASET
       - BQ_CREDENTIALS_TYPE
@@ -15,6 +16,15 @@ services:
       - BQ_CREDENTIALS_AUTH_PROVIDER_X509_CERT_URL
       - BQ_CREDENTIALS_CLIENT_X509_CERT_URL
       - KBC_RUNID
+  dev: &dev
+    <<: *prod
+    image: keboola/google-bigquery-transformation
+    volumes:
+      - ./:/code
+      - ./data:/data
+  dev-xdebug:
+    <<: *dev
+    build: docker/xdebug
     volumes:
       - ./:/code
       - ./data:/data

--- a/docker/xdebug/Dockerfile
+++ b/docker/xdebug/Dockerfile
@@ -1,0 +1,4 @@
+FROM keboola/google-bigquery-transformation
+
+RUN pecl install xdebug \
+  && docker-php-ext-enable xdebug

--- a/patches/google-cloud-bigquery-JobWaitTrait.php.patch
+++ b/patches/google-cloud-bigquery-JobWaitTrait.php.patch
@@ -1,0 +1,13 @@
+--- src/JobWaitTrait.php	2023-11-01 13:07:13.826212516 +0100
++++ src/JobWaitTrait.php	2023-11-01 13:07:24.542742533 +0100
+@@ -55,7 +55,9 @@
+                 }
+             };
+
+-            (new ExponentialBackoff($maxRetries))
++            (new ExponentialBackoff($maxRetries, function (\Throwable $e) {
++                return $e->getCode() !== 499;
++            }))
+                 ->execute($retryFn);
+         }
+     }

--- a/src/Client/Retry.php
+++ b/src/Client/Retry.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BigQueryTransformation\Client;
+
+use Google\Cloud\Core\JsonTrait;
+use GuzzleHttp\Exception\RequestException;
+use InvalidArgumentException;
+use Throwable;
+
+final class Retry
+{
+    use JsonTrait;
+
+    private const RETRY_MISSING_CREATE_JOB = 'bigquery.jobs.create';
+    private const RETRY_ON_REASON = [
+        'rateLimitExceeded',
+        'userRateLimitExceeded',
+        'backendError',
+        'jobRateLimitExceeded',
+    ];
+
+    public static function shouldRetryException(Throwable $ex): bool
+    {
+        $statusCode = $ex->getCode();
+
+        if (in_array($statusCode, [429, 500, 503,])) {
+            return true;
+        }
+        if ($statusCode >= 200 && $statusCode < 300) {
+            return false;
+        }
+
+        $message = $ex->getMessage();
+        if ($ex instanceof RequestException && $ex->hasResponse()) {
+            $message = (string) $ex->getResponse()?->getBody();
+        }
+
+        try {
+            $message = self::jsonDecode(
+                $message,
+                true
+            );
+        } catch (InvalidArgumentException $ex) {
+            return false;
+        }
+
+        if (!is_array($message)) {
+            return false;
+        }
+
+        if (!array_key_exists('error', $message)) {
+            return false;
+        }
+
+        if (is_string($message['error']) && str_contains($message['error'], 'invalid_grant')) {
+            // {"error":"invalid_grant","error_description":"Invalid JWT Signature."}
+            return true;
+        }
+
+        if (!array_key_exists('errors', $message['error'])) {
+            return false;
+        }
+
+        if (!is_array($message['error']['errors'])) {
+            return false;
+        }
+
+        foreach ($message['error']['errors'] as $error) {
+            if (array_key_exists('reason', $error)
+                && in_array($error['reason'], self::RETRY_ON_REASON, false)
+            ) {
+                return true;
+            }
+            if (array_key_exists('message', $error)
+                && str_contains($error['message'], self::RETRY_MISSING_CREATE_JOB)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/phpunit/Client/RetryTest.php
+++ b/tests/phpunit/Client/RetryTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BigQueryTransformation\Tests\Client;
+
+use BigQueryTransformation\Client\Retry;
+use Exception;
+use Generator;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+class RetryTest extends TestCase
+{
+    private function getException(int $code, string $message = ''): Throwable
+    {
+        return new Exception($message, $code);
+    }
+
+    private function getRequestException(int $code, ?string $message = ''): Throwable
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn(Utils::streamFor($message));
+        return new RequestException(
+            '',
+            $this->createMock(RequestInterface::class),
+            $response,
+            $this->getException($code)
+        );
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function retryCodesProvider(): array
+    {
+        return [
+            [200],
+            [210],
+            [299],
+        ];
+    }
+
+    /**
+     * @dataProvider retryCodesProvider
+     */
+    public function testSuccessResponse(int $statusCode): void
+    {
+        $ex = $this->getException($statusCode);
+        $this->assertFalse(Retry::shouldRetryException($ex));
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function retryCodesErrorProvider(): array
+    {
+        return [
+            [429],
+            [500],
+            [503],
+        ];
+    }
+
+    /**
+     * @dataProvider retryCodesErrorProvider
+     */
+    public function testRetryOnCodesResponse(int $statusCode): void
+    {
+        $ex = $this->getException($statusCode);
+        $this->assertTrue(Retry::shouldRetryException($ex));
+    }
+
+    public function testNotJsonResponse(): void
+    {
+        $ex = $this->getException(418, 'not json');
+        $this->assertFalse(Retry::shouldRetryException($ex));
+    }
+
+    public function testNotExpectedContentResponse(): void
+    {
+        $ex = $this->getException(418, '{"data" : "test"}');
+        $this->assertFalse(Retry::shouldRetryException($ex));
+    }
+
+    public function responseContentProvider(): Generator
+    {
+        foreach (['Throwable', 'RequestException'] as $exceptionType) {
+            yield 'not error response ' . ' ' . $exceptionType => [
+                '{"data" : "test"}',
+                false,
+                $exceptionType,
+            ];
+
+            yield 'errors not array' . ' ' . $exceptionType => [
+                '{"error": { "errors" : "test" }}',
+                false,
+                $exceptionType,
+            ];
+
+            yield 'errors empty array' . ' ' . $exceptionType => [
+                '{"error": { "errors" : [] }}',
+                false,
+                $exceptionType,
+            ];
+            yield 'errors expected errors[0]' . ' ' . $exceptionType => [
+                '{"error": { "errors" : [{"test":"test"}] }}',
+                false,
+                $exceptionType,
+            ];
+
+            yield 'errors no reason ' . $exceptionType => [
+                '{"error": { "errors" : [{"message":"bigquery.jobs.create"}] }}',
+                true,
+                $exceptionType,
+            ];
+
+            yield 'errors no message ' . $exceptionType => [
+                '{"error": { "errors" : [{"reason":"userRateLimitExceeded"}] }}',
+                true,
+                $exceptionType,
+            ];
+
+            yield 'unknown reason and message ' . $exceptionType => [
+                '{"error": { "errors" : [{"reason":"unknown","message": "unknown"}] }}',
+                false,
+                $exceptionType,
+            ];
+
+            yield 'Invalid JWT Signature ' . $exceptionType => [
+                '{"error":"invalid_grant","error_description":"Invalid JWT Signature."}',
+                true,
+                $exceptionType,
+            ];
+
+            /**
+             * @var array{error:array{
+             *     code:int,
+             *     message:string,
+             *     status:string,
+             *     errors:array<array{
+             *          message:string,
+             *          domain:string,
+             *          reason:string
+             *     }>
+             *   }} $json
+             */
+            $json = json_decode(<<<EOD
+{
+    "error": {
+        "code": 404,
+        "message": "Not found: xxx",
+        "errors": [
+            {
+                "message": "Not found: xxx",
+                "domain": "global",
+                "reason": "notFound"
+            }
+        ],
+        "status": "NOT_FOUND"
+    }
+}
+EOD, true, 512, JSON_THROW_ON_ERROR);
+
+            foreach ([
+                         'rateLimitExceeded',
+                         'userRateLimitExceeded',
+                         'backendError',
+                         'jobRateLimitExceeded',
+                     ] as $reason) {
+                $json['error']['errors'][0]['reason'] = $reason;
+                yield 'retry on ' . $reason . ' ' . $exceptionType => [
+                    json_encode($json, JSON_THROW_ON_ERROR),
+                    true,
+                    $exceptionType,
+                ];
+            }
+
+            $json['error']['errors'][0]['reason'] = 'unknown';
+            yield 'not retry on unknown reason ' . $exceptionType => [
+                json_encode($json, JSON_THROW_ON_ERROR),
+                false,
+                $exceptionType,
+            ];
+
+            foreach (['bigquery.jobs.create'] as $msg) {
+                $json['error']['errors'][0]['reason'] = 'unknown';
+                $json['error']['errors'][0]['message'] = $msg;
+                yield sprintf('retry on message "%s" "%s"', $msg, $exceptionType) => [
+                    json_encode($json, JSON_THROW_ON_ERROR),
+                    true,
+                    $exceptionType,
+                ];
+            }
+        }
+    }
+
+    /**
+     * @dataProvider responseContentProvider
+     */
+    public function testResponseContent(string $json, bool $expectToRetry, string $exceptionType): void
+    {
+        $ex = $this->getException(418, $json);
+        if ($exceptionType === 'RequestException') {
+            $this->getRequestException(418, $json);
+        }
+
+        $this->assertSame($expectToRetry, Retry::shouldRetryException($ex));
+    }
+}


### PR DESCRIPTION
JIRA: GCP-409 GCP-400

- refactoring of retry logic to own class + unit tests
- retry now handles invalid_grant error
- fix retry which google client expects sometimes to return retry function and sometimes calling directly
- add vendor patch so job with 499 error is not waiting indefinitely 