### PR TITLE
Add branch_id label to BigQuery queries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8-cli
+FROM php:8.2-cli
 
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive

--- a/src/BigQueryConnection.php
+++ b/src/BigQueryConnection.php
@@ -90,6 +90,12 @@ class BigQueryConnection
     {
         $queryOptions = $this->session->getAsQueryOptions();
         $queryOptions['configuration']['labels'] = ['run_id' => $this->runId];
+
+        $branchId = getenv('KBC_BRANCHID');
+        if ($branchId) {
+            $queryOptions['configuration']['labels']['branch_id'] = $branchId;
+        }
+
         if ($this->queryTimeout !== 0) {
             $queryOptions['configuration']['jobTimeoutMs'] = $this->queryTimeout * 1000;
         }


### PR DESCRIPTION
This PR adds branch_id label to BigQuery queries when KBC_BRANCHID environment variable is set. A test has been added to verify this functionality.